### PR TITLE
feat: mix with regexp object

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,16 @@ TS Regex Builder allows you to build complex regular expressions using domain-sp
 
 Terminology:
 - regex construct (`RegexConstruct`) - common name for all regex constructs like character classes, quantifiers, and anchors.
-- regex element (`RegexElement`) - a fundamental building block of a regular expression, defined as either a regex construct or a string.
+- regex element (`RegexElement`) - a fundamental building block of a regular expression, defined as either a regex construct, a string, or `RegExp` literal (`/.../`).
 - regex sequence (`RegexSequence`) - a sequence of regex elements forming a regular expression. For developer convenience, it also accepts a single element instead of an array.
 
 Most of the regex constructs accept a regex sequence as their argument.
 
 Examples of sequences:
-- single element (construct): `capture('abc')`
+- single element (construct): `capture('Hello')`
 - single element (string): `'Hello'`
-- array of elements: `['USD', oneOrMore(digit)]`
+- single element (`RegExp` literal): `/Hello/`
+- array of elements: `['USD', oneOrMore(digit), /Hello/]`
 
 Regex constructs can be composed into a tree structure:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ The sequence of regex elements forming a regular expression. For developer conve
 
 ### `RegexElement`
 
-Fundamental building blocks of a regular expression, defined as either a regex construct or a string.
+Fundamental building blocks of a regular expression, defined as either a regex construct, a string, or a `RegExp` literal (`/.../`).
 
 ### `RegexConstruct`
 

--- a/src/encoder/__tests__/encoder.test.tsx
+++ b/src/encoder/__tests__/encoder.test.tsx
@@ -46,12 +46,23 @@ test('`buildPattern` escapes special characters', () => {
 });
 
 test('`buildRegExp` accepts RegExp object', () => {
-  expect(buildRegExp(/a/)).toEqual(/a/);
-  expect(buildRegExp(oneOrMore(/a/))).toEqual(/(?:a)+/);
-  expect(buildRegExp(repeat(/a/, 5))).toEqual(/(?:a){5}/);
-  expect(buildRegExp(capture(/a/))).toEqual(/(a)/);
+  expect(buildRegExp(/abc/)).toEqual(/abc/);
+  expect(buildRegExp(oneOrMore(/abc/))).toEqual(/(?:abc)+/);
+  expect(buildRegExp(repeat(/abc/, 5))).toEqual(/(?:abc){5}/);
+  expect(buildRegExp(capture(/abc/))).toEqual(/(abc)/);
   expect(buildRegExp(choiceOf(/a/, /b/))).toEqual(/a|b/);
   expect(buildRegExp(choiceOf(/a|b/, /c/))).toEqual(/a|b|c/);
+});
+
+test('`buildRegExp` detects common atomic patterns', () => {
+  expect(buildRegExp(/a/)).toEqual(/a/);
+  expect(buildRegExp(/[a-z]/)).toEqual(/[a-z]/);
+  expect(buildRegExp(/(abc)/)).toEqual(/(abc)/);
+  expect(buildRegExp(oneOrMore(/a/))).toEqual(/a+/);
+  expect(buildRegExp(oneOrMore(/[a-z]/))).toEqual(/[a-z]+/);
+  expect(buildRegExp(oneOrMore(/(abc)/))).toEqual(/(abc)+/);
+  expect(buildRegExp(repeat(/a/, 5))).toEqual(/a{5}/);
+  expect(buildRegExp(oneOrMore(/(a|b|c)/))).toEqual(/(a|b|c)+/);
 });
 
 test('`buildRegExp` throws error on unknown element', () => {

--- a/src/encoder/__tests__/encoder.test.tsx
+++ b/src/encoder/__tests__/encoder.test.tsx
@@ -1,4 +1,6 @@
 import { buildPattern, buildRegExp } from '../../builders';
+import { capture } from '../../constructs/capture';
+import { choiceOf } from '../../constructs/choice-of';
 import { oneOrMore, optional, zeroOrMore } from '../../constructs/quantifiers';
 import { repeat } from '../../constructs/repeat';
 
@@ -41,6 +43,15 @@ test('`buildPattern` escapes special characters', () => {
   expect('*.*').toEqualRegex(/\*\.\*/);
 
   expect([oneOrMore('.*'), zeroOrMore('[]{}')]).toEqualRegex(/(?:\.\*)+(?:\[\]\{\})*/);
+});
+
+test('`buildRegExp` accepts RegExp object', () => {
+  expect(buildRegExp(/a/)).toEqual(/a/);
+  expect(buildRegExp(oneOrMore(/a/))).toEqual(/(?:a)+/);
+  expect(buildRegExp(repeat(/a/, 5))).toEqual(/(?:a){5}/);
+  expect(buildRegExp(capture(/a/))).toEqual(/(a)/);
+  expect(buildRegExp(choiceOf(/a/, /b/))).toEqual(/a|b/);
+  expect(buildRegExp(choiceOf(/a|b/, /c/))).toEqual(/a|b|c/);
 });
 
 test('`buildRegExp` throws error on unknown element', () => {

--- a/src/encoder/encoder.ts
+++ b/src/encoder/encoder.ts
@@ -53,11 +53,28 @@ function encodeRegExp(regexp: RegExp): EncodeResult {
     throw new Error('`encodeRegExp`: received regexp should not be empty');
   }
 
-  // Encode as lowest priority
+  // Encode at safe precedence
   return {
-    precedence: 'disjunction',
+    precedence: isAtomicPattern(regexp.source) ? 'atom' : 'disjunction',
     pattern,
   };
+}
+
+// This is intended to catch only some popular atomic patterns like char classes.
+function isAtomicPattern(pattern: string): boolean {
+  if (pattern.length === 1) {
+    return true;
+  }
+
+  if (pattern.startsWith('[') && pattern.endsWith(']') && pattern.match(/[[\]]/g)?.length === 2) {
+    return true;
+  }
+
+  if (pattern.startsWith('(') && pattern.endsWith(')') && pattern.match(/[()]/g)?.length === 2) {
+    return true;
+  }
+
+  return false;
 }
 
 function concatSequence(encoded: EncodeResult[]): EncodeResult {

--- a/src/encoder/encoder.ts
+++ b/src/encoder/encoder.ts
@@ -16,6 +16,10 @@ function encodeNode(element: RegexElement): EncodeResult {
     return encodeText(element);
   }
 
+  if (typeof element === 'object' && element instanceof RegExp) {
+    return encodeRegExp(element);
+  }
+
   if (typeof element.encode !== 'function') {
     throw new Error(`\`encodeNode\`: unknown element type ${element.type}`);
   }
@@ -39,6 +43,20 @@ function encodeText(text: string): EncodeResult {
   return {
     precedence: 'sequence',
     pattern: escapeText(text),
+  };
+}
+
+function encodeRegExp(regexp: RegExp): EncodeResult {
+  const pattern = regexp.source;
+
+  if (pattern.length === 0) {
+    throw new Error('`encodeRegExp`: received regexp should not be empty');
+  }
+
+  // Encode as lowest priority
+  return {
+    precedence: 'disjunction',
+    pattern,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type RegexSequence = RegexElement[] | RegexElement;
 /**
  * Fundamental building block of a regular expression, defined as either a regex construct or a string.
  */
-export type RegexElement = RegexConstruct | string;
+export type RegexElement = RegexConstruct | string | RegExp;
 
 /**
  * Common interface for all regex constructs like character classes, quantifiers, and anchors.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds ability to pass RegExp literals (or objects) as regex elements to allow mixing of simple regex literals (e.g. char classes) with structural regex builder calls.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
