### PR TITLE
feat: non-greedy quantifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,19 @@ See [API document](./docs/API.md).
 
 ### Quantifiers
 
-| Quantifier                       | Regex Syntax | Description                                       |
-| -------------------------------- | ------------ | ------------------------------------------------- |
-| `zeroOrMore(x)`                  | `x*`         | Zero or more occurence of a pattern               |
-| `oneOrMore(x)`                   | `x+`         | One or more occurence of a pattern                |
-| `optional(x)`                    | `x?`         | Zero or one occurence of a pattern                |
-| `repeat(x, n)`                   | `x{n}`       | Pattern repeats exact number of times             |
-| `repeat(x, { min: n, })`         | `x{n,}`      | Pattern repeats at least given number of times    |
-| `repeat(x, { min: n, max: n2 })` | `x{n1,n2}`   | Pattern repeats between n1 and n2 number of times |
+| Quantifier                                      | Regex Syntax | Description                                                    |
+| ----------------------------------------------- | ------------ | -------------------------------------------------------------- |
+| `zeroOrMore(x)`                                 | `x*`         | Zero or more occurence of a pattern                            |
+| `zeroOrMore(x, { greedy: false })`              | `x*?`        | Zero or more occurence of a pattern (non-greedy)               |
+| `oneOrMore(x)`                                  | `x+`         | One or more occurence of a pattern                             |
+| `oneOrMore(x, { greedy: false })`               | `x+?`        | One or more occurence of a pattern (non-greedy)                |
+| `optional(x)`                                   | `x?`         | Zero or one occurence of a pattern                             |
+| `optional(x, { greedy: false })`                | `x??`        | Zero or one occurence of a pattern (non-greedy)                |
+| `repeat(x, n)`                                  | `x{n}`       | Pattern repeats exact number of times                          |
+| `repeat(x, { min: n, })`                        | `x{n,}`      | Pattern repeats at least given number of times                 |
+| `repeat(x, { min: n, greedy: false })`          | `x{n,}?`     | Pattern repeats at least given number of times (non-greedy)    |
+| `repeat(x, { min: n, max: n2 })`                | `x{n1,n2}`   | Pattern repeats between n1 and n2 number of times              |
+| `repeat(x, { min: n, max: n2, greedy: false })` | `x{n1,n2}?`  | Pattern repeats between n1 and n2 number of times (non-greedy) |
 
 ### Character classes
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -88,8 +88,8 @@ function zeroOrMore(
 ```
 
 Regex syntax:
-* `x*` for default greedy behavior
-* `x*?` for non-greedy behavior
+* `x*` for default greedy behavior (match as many characters as possible)
+* `x*?` for non-greedy behavior (match as few characters as possible)
 
 The `zeroOrMore` quantifier matches zero or more occurrences of a given pattern, allowing a flexible number of repetitions of that element.
 
@@ -105,8 +105,8 @@ function oneOrMore(
 ```
 
 Regex syntax:
-* `x+` for default greedy behavior
-* `x+?` for non-greedy behavior
+* `x+` for default greedy behavior (match as many characters as possible)
+* `x+?` for non-greedy behavior (match as few characters as possible)
 
 The `oneOrMore` quantifier matches one or more occurrences of a given pattern, allowing a flexible number of repetitions of that element.
 
@@ -122,8 +122,8 @@ function optional(
 ```
 
 Regex syntax:
-* `x?` for default greedy behavior
-* `x??` for non-greedy behavior
+* `x?` for default greedy behavior (match as many characters as possible)
+* `x??` for non-greedy behavior (match as few characters as possible)
 
 The `optional` quantifier matches zero or one occurrence of a given pattern, making it optional.
 
@@ -141,8 +141,8 @@ function repeat(
 ```
 
 Regex syntax:
-* `x{n}`, `x{min,}`, `x{min, max}` for default greedy behavior
-* `x{min,}?`, `x{min, max}?` for non-greedy behavior
+* `x{n}`, `x{min,}`, `x{min, max}` for default greedy behavior (match as many characters as possible)
+* `x{min,}?`, `x{min, max}?` for non-greedy behavior (match as few characters as possible)
 
 The `repeat` quantifier in regex matches either exactly `count` times or between `min` and `max` times. If only `min` is provided, it matches at least `min` times.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -81,13 +81,15 @@ Quantifiers in regex define the number of occurrences to match for a pattern.
 ```ts
 function zeroOrMore(
   sequence: RegexSequence,
-  behavior: "greedy" | "lazy" = "greedy",
+  options?: {
+    greedy?: boolean, // default = true
+  }
 ): ZeroOrMore
 ```
 
 Regex syntax:
 * `x*` for default greedy behavior
-* `x*?` for lazy behavior
+* `x*?` for non-greedy behavior
 
 The `zeroOrMore` quantifier matches zero or more occurrences of a given pattern, allowing a flexible number of repetitions of that element.
 
@@ -96,13 +98,15 @@ The `zeroOrMore` quantifier matches zero or more occurrences of a given pattern,
 ```ts
 function oneOrMore(
   sequence: RegexSequence,
-  behavior: "greedy" | "lazy" = "greedy",
+  options?: {
+    greedy?: boolean, // default = true
+  }
 ): OneOrMore
 ```
 
 Regex syntax:
 * `x+` for default greedy behavior
-* `x+?` for lazy behavior
+* `x+?` for non-greedy behavior
 
 The `oneOrMore` quantifier matches one or more occurrences of a given pattern, allowing a flexible number of repetitions of that element.
 
@@ -111,13 +115,15 @@ The `oneOrMore` quantifier matches one or more occurrences of a given pattern, a
 ```ts
 function optional(
   sequence: RegexSequence,
-  behavior: "greedy" | "lazy" = "greedy",
+  options?: {
+    greedy?: boolean, // default = true
+  }
 ): Optionally
 ```
 
 Regex syntax:
 * `x?` for default greedy behavior
-* `x??` for lazy behavior
+* `x??` for non-greedy behavior
 
 The `optional` quantifier matches zero or one occurrence of a given pattern, making it optional.
 
@@ -126,14 +132,13 @@ The `optional` quantifier matches zero or one occurrence of a given pattern, mak
 ```ts
 function repeat(
   sequence: RegexSequence,
-  count: number | { min: number; max?: number },
-  behavior: "greedy" | "lazy" = "greedy",
+  options: number | { min: number; max?: number, greedy?: boolean  },
 ): Repeat
 ```
 
 Regex syntax:
 * `x{n}`, `x{min,}`, `x{min, max}` for default greedy behavior
-* `x{n}?`, `x{min,}?`, `x{min, max}?` for lazy behavior
+* `x{min,}?`, `x{min, max}?` for non-greedy behavior
 
 The `repeat` quantifier in regex matches either exactly `count` times or between `min` and `max` times. If only `min` is provided, it matches at least `min` times.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -82,7 +82,7 @@ Quantifiers in regex define the number of occurrences to match for a pattern.
 function zeroOrMore(
   sequence: RegexSequence,
   options?: {
-    greedy?: boolean, // default = true
+    greedy?: boolean, // default=true
   }
 ): ZeroOrMore
 ```
@@ -99,7 +99,7 @@ The `zeroOrMore` quantifier matches zero or more occurrences of a given pattern,
 function oneOrMore(
   sequence: RegexSequence,
   options?: {
-    greedy?: boolean, // default = true
+    greedy?: boolean, // default=true
   }
 ): OneOrMore
 ```
@@ -116,7 +116,7 @@ The `oneOrMore` quantifier matches one or more occurrences of a given pattern, a
 function optional(
   sequence: RegexSequence,
   options?: {
-    greedy?: boolean, // default = true
+    greedy?: boolean, // default=true
   }
 ): Optionally
 ```
@@ -132,7 +132,11 @@ The `optional` quantifier matches zero or one occurrence of a given pattern, mak
 ```ts
 function repeat(
   sequence: RegexSequence,
-  options: number | { min: number; max?: number, greedy?: boolean  },
+  options: number | { 
+    min: number;
+    max?: number; 
+    greedy?: boolean;  // default=true
+  },
 ): Repeat
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -81,10 +81,13 @@ Quantifiers in regex define the number of occurrences to match for a pattern.
 ```ts
 function zeroOrMore(
   sequence: RegexSequence,
+  behavior: "greedy" | "lazy" = "greedy",
 ): ZeroOrMore
 ```
 
-Regex syntax: `x*`;
+Regex syntax:
+* `x*` for default greedy behavior
+* `x*?` for lazy behavior
 
 The `zeroOrMore` quantifier matches zero or more occurrences of a given pattern, allowing a flexible number of repetitions of that element.
 
@@ -93,10 +96,13 @@ The `zeroOrMore` quantifier matches zero or more occurrences of a given pattern,
 ```ts
 function oneOrMore(
   sequence: RegexSequence,
+  behavior: "greedy" | "lazy" = "greedy",
 ): OneOrMore
 ```
 
-Regex syntax: `x+`;
+Regex syntax:
+* `x+` for default greedy behavior
+* `x+?` for lazy behavior
 
 The `oneOrMore` quantifier matches one or more occurrences of a given pattern, allowing a flexible number of repetitions of that element.
 
@@ -105,10 +111,13 @@ The `oneOrMore` quantifier matches one or more occurrences of a given pattern, a
 ```ts
 function optional(
   sequence: RegexSequence,
+  behavior: "greedy" | "lazy" = "greedy",
 ): Optionally
 ```
 
-Regex syntax: `x?`;
+Regex syntax:
+* `x?` for default greedy behavior
+* `x??` for lazy behavior
 
 The `optional` quantifier matches zero or one occurrence of a given pattern, making it optional.
 
@@ -118,10 +127,13 @@ The `optional` quantifier matches zero or one occurrence of a given pattern, mak
 function repeat(
   sequence: RegexSequence,
   count: number | { min: number; max?: number },
+  behavior: "greedy" | "lazy" = "greedy",
 ): Repeat
 ```
 
-Regex syntax: `x{n}`, `x{min,}`, `x{min, max}`.
+Regex syntax:
+* `x{n}`, `x{min,}`, `x{min, max}` for default greedy behavior
+* `x{n}?`, `x{min,}?`, `x{min, max}?` for lazy behavior
 
 The `repeat` quantifier in regex matches either exactly `count` times or between `min` and `max` times. If only `min` is provided, it matches at least `min` times.
 

--- a/src/constructs/__tests__/quantifiers.test.tsx
+++ b/src/constructs/__tests__/quantifiers.test.tsx
@@ -45,8 +45,8 @@ test('greedy quantifiers', () => {
   expect(optional('a', 'greedy')).toEqualRegex(/a?/);
   expect(optional('ab', 'greedy')).toEqualRegex(/(?:ab)?/);
 
-  expect(zeroOrMore('a', 'greedy')).toEqualRegex(/a*/);
-  expect(zeroOrMore('ab', 'greedy')).toEqualRegex(/(?:ab)*/);
+  expect(zeroOrMore('a', { behavior: 'lazy' })).toEqualRegex(/a*/);
+  expect(zeroOrMore('ab', { behavior: 'lazy' })).toEqualRegex(/(?:ab)*/);
 });
 
 test('lazy quantifiers', () => {
@@ -56,6 +56,6 @@ test('lazy quantifiers', () => {
   expect(optional('a', 'lazy')).toEqualRegex(/a??/);
   expect(optional('ab', 'lazy')).toEqualRegex(/(?:ab)??/);
 
-  expect(zeroOrMore('a', 'lazy')).toEqualRegex(/a*?/);
-  expect(zeroOrMore('ab', 'lazy')).toEqualRegex(/(?:ab)*?/);
+  expect(zeroOrMore('a', { behavior: 'lazy' })).toEqualRegex(/a*?/);
+  expect(zeroOrMore('ab', { behavior: 'lazy' })).toEqualRegex(/(?:ab)*?/);
 });

--- a/src/constructs/__tests__/quantifiers.test.tsx
+++ b/src/constructs/__tests__/quantifiers.test.tsx
@@ -39,23 +39,23 @@ test('base quantifiers optimize grouping for atoms', () => {
 });
 
 test('greedy quantifiers', () => {
-  expect(oneOrMore('a', 'greedy')).toEqualRegex(/a+/);
-  expect(oneOrMore('ab', 'greedy')).toEqualRegex(/(?:ab)+/);
+  expect(oneOrMore('a', { greedy: true })).toEqualRegex(/a+/);
+  expect(oneOrMore('ab', { greedy: true })).toEqualRegex(/(?:ab)+/);
 
-  expect(optional('a', 'greedy')).toEqualRegex(/a?/);
-  expect(optional('ab', 'greedy')).toEqualRegex(/(?:ab)?/);
+  expect(optional('a', { greedy: true })).toEqualRegex(/a?/);
+  expect(optional('ab', { greedy: true })).toEqualRegex(/(?:ab)?/);
 
-  expect(zeroOrMore('a', 'greedy')).toEqualRegex(/a*/);
-  expect(zeroOrMore('ab', 'greedy')).toEqualRegex(/(?:ab)*/);
+  expect(zeroOrMore('a', { greedy: true })).toEqualRegex(/a*/);
+  expect(zeroOrMore('ab', { greedy: true })).toEqualRegex(/(?:ab)*/);
 });
 
-test('lazy quantifiers', () => {
-  expect(oneOrMore('a', 'lazy')).toEqualRegex(/a+?/);
-  expect(oneOrMore('ab', 'lazy')).toEqualRegex(/(?:ab)+?/);
+test('non-greedy quantifiers', () => {
+  expect(oneOrMore('a', { greedy: false })).toEqualRegex(/a+?/);
+  expect(oneOrMore('ab', { greedy: false })).toEqualRegex(/(?:ab)+?/);
 
-  expect(optional('a', 'lazy')).toEqualRegex(/a??/);
-  expect(optional('ab', 'lazy')).toEqualRegex(/(?:ab)??/);
+  expect(optional('a', { greedy: false })).toEqualRegex(/a??/);
+  expect(optional('ab', { greedy: false })).toEqualRegex(/(?:ab)??/);
 
-  expect(zeroOrMore('a', 'lazy')).toEqualRegex(/a*?/);
-  expect(zeroOrMore('ab', 'lazy')).toEqualRegex(/(?:ab)*?/);
+  expect(zeroOrMore('a', { greedy: false })).toEqualRegex(/a*?/);
+  expect(zeroOrMore('ab', { greedy: false })).toEqualRegex(/(?:ab)*?/);
 });

--- a/src/constructs/__tests__/quantifiers.test.tsx
+++ b/src/constructs/__tests__/quantifiers.test.tsx
@@ -45,8 +45,8 @@ test('greedy quantifiers', () => {
   expect(optional('a', 'greedy')).toEqualRegex(/a?/);
   expect(optional('ab', 'greedy')).toEqualRegex(/(?:ab)?/);
 
-  expect(zeroOrMore('a', { behavior: 'lazy' })).toEqualRegex(/a*/);
-  expect(zeroOrMore('ab', { behavior: 'lazy' })).toEqualRegex(/(?:ab)*/);
+  expect(zeroOrMore('a', 'greedy')).toEqualRegex(/a*/);
+  expect(zeroOrMore('ab', 'greedy')).toEqualRegex(/(?:ab)*/);
 });
 
 test('lazy quantifiers', () => {
@@ -56,6 +56,6 @@ test('lazy quantifiers', () => {
   expect(optional('a', 'lazy')).toEqualRegex(/a??/);
   expect(optional('ab', 'lazy')).toEqualRegex(/(?:ab)??/);
 
-  expect(zeroOrMore('a', { behavior: 'lazy' })).toEqualRegex(/a*?/);
-  expect(zeroOrMore('ab', { behavior: 'lazy' })).toEqualRegex(/(?:ab)*?/);
+  expect(zeroOrMore('a', 'lazy')).toEqualRegex(/a*?/);
+  expect(zeroOrMore('ab', 'lazy')).toEqualRegex(/(?:ab)*?/);
 });

--- a/src/constructs/__tests__/quantifiers.test.tsx
+++ b/src/constructs/__tests__/quantifiers.test.tsx
@@ -37,3 +37,25 @@ test('base quantifiers optimize grouping for atoms', () => {
   expect(optional('a')).toEqualRegex(/a?/);
   expect(zeroOrMore('a')).toEqualRegex(/a*/);
 });
+
+test('greedy quantifiers', () => {
+  expect(oneOrMore('a', 'greedy')).toEqualRegex(/a+/);
+  expect(oneOrMore('ab', 'greedy')).toEqualRegex(/(?:ab)+/);
+
+  expect(optional('a', 'greedy')).toEqualRegex(/a?/);
+  expect(optional('ab', 'greedy')).toEqualRegex(/(?:ab)?/);
+
+  expect(zeroOrMore('a', 'greedy')).toEqualRegex(/a*/);
+  expect(zeroOrMore('ab', 'greedy')).toEqualRegex(/(?:ab)*/);
+});
+
+test('lazy quantifiers', () => {
+  expect(oneOrMore('a', 'lazy')).toEqualRegex(/a+?/);
+  expect(oneOrMore('ab', 'lazy')).toEqualRegex(/(?:ab)+?/);
+
+  expect(optional('a', 'lazy')).toEqualRegex(/a??/);
+  expect(optional('ab', 'lazy')).toEqualRegex(/(?:ab)??/);
+
+  expect(zeroOrMore('a', 'lazy')).toEqualRegex(/a*?/);
+  expect(zeroOrMore('ab', 'lazy')).toEqualRegex(/(?:ab)*?/);
+});

--- a/src/constructs/__tests__/repeat.test.tsx
+++ b/src/constructs/__tests__/repeat.test.tsx
@@ -22,3 +22,15 @@ test('`repeat` throws on no children', () => {
     `"\`repeat\` should receive at least one element"`,
   );
 });
+
+test('greedy `repeat` quantifier', () => {
+  expect(repeat('a', 2, 'greedy')).toEqualRegex(/a{2}/);
+  expect(repeat('a', { min: 1 }, 'greedy')).toEqualRegex(/a{1,}/);
+  expect(repeat('a', { min: 1, max: 5 }, 'greedy')).toEqualRegex(/a{1,5}/);
+});
+
+test('lazy `repeat` quantifier', () => {
+  expect(repeat('a', 2, 'lazy')).toEqualRegex(/a{2}?/);
+  expect(repeat('a', { min: 1 }, 'lazy')).toEqualRegex(/a{1,}?/);
+  expect(repeat('a', { min: 1, max: 5 }, 'lazy')).toEqualRegex(/a{1,5}?/);
+});

--- a/src/constructs/__tests__/repeat.test.tsx
+++ b/src/constructs/__tests__/repeat.test.tsx
@@ -24,13 +24,11 @@ test('`repeat` throws on no children', () => {
 });
 
 test('greedy `repeat` quantifier', () => {
-  expect(repeat('a', 2, 'greedy')).toEqualRegex(/a{2}/);
-  expect(repeat('a', { min: 1 }, 'greedy')).toEqualRegex(/a{1,}/);
-  expect(repeat('a', { min: 1, max: 5 }, 'greedy')).toEqualRegex(/a{1,5}/);
+  expect(repeat('a', { min: 1, greedy: true })).toEqualRegex(/a{1,}/);
+  expect(repeat('a', { min: 1, max: 5, greedy: true })).toEqualRegex(/a{1,5}/);
 });
 
-test('lazy `repeat` quantifier', () => {
-  expect(repeat('a', 2, 'lazy')).toEqualRegex(/a{2}?/);
-  expect(repeat('a', { min: 1 }, 'lazy')).toEqualRegex(/a{1,}?/);
-  expect(repeat('a', { min: 1, max: 5 }, 'lazy')).toEqualRegex(/a{1,5}?/);
+test('non-greedy `repeat` quantifier', () => {
+  expect(repeat('a', { min: 1, greedy: false })).toEqualRegex(/a{1,}?/);
+  expect(repeat('a', { min: 1, max: 5, greedy: false })).toEqualRegex(/a{1,5}?/);
 });

--- a/src/constructs/quantifiers.ts
+++ b/src/constructs/quantifiers.ts
@@ -5,10 +5,12 @@ import type { RegexConstruct, RegexElement, RegexSequence } from '../types';
 
 export type QuantifierBehavior = 'greedy' | 'lazy';
 
+export type QuantifierOptions = { behavior?: QuantifierBehavior };
+
 export interface ZeroOrMore extends RegexConstruct {
   type: 'zeroOrMore';
   children: RegexElement[];
-  behavior: QuantifierBehavior;
+  options: QuantifierOptions;
 }
 
 export interface OneOrMore extends RegexConstruct {
@@ -23,10 +25,10 @@ export interface Optional extends RegexConstruct {
   behavior: QuantifierBehavior;
 }
 
-export function zeroOrMore(sequence: RegexSequence, behavior?: QuantifierBehavior): ZeroOrMore {
+export function zeroOrMore(sequence: RegexSequence, options?: QuantifierOptions): ZeroOrMore {
   return {
     type: 'zeroOrMore',
-    behavior: validateBehavior(behavior),
+    options: { behavior: validateBehavior(options?.behavior) },
     children: ensureArray(sequence),
     encode: encodeZeroOrMore,
   };
@@ -53,7 +55,7 @@ export function optional(sequence: RegexSequence, behavior?: QuantifierBehavior)
 function encodeZeroOrMore(this: ZeroOrMore): EncodeResult {
   return {
     precedence: 'sequence',
-    pattern: `${encodeAtom(this.children).pattern}*${this.behavior === 'lazy' ? '?' : ''}`,
+    pattern: `${encodeAtom(this.children).pattern}*${this.options.behavior === 'lazy' ? '?' : ''}`,
   };
 }
 

--- a/src/constructs/quantifiers.ts
+++ b/src/constructs/quantifiers.ts
@@ -5,12 +5,10 @@ import type { RegexConstruct, RegexElement, RegexSequence } from '../types';
 
 export type QuantifierBehavior = 'greedy' | 'lazy';
 
-export type QuantifierOptions = { behavior?: QuantifierBehavior };
-
 export interface ZeroOrMore extends RegexConstruct {
   type: 'zeroOrMore';
   children: RegexElement[];
-  options: QuantifierOptions;
+  behavior: QuantifierBehavior;
 }
 
 export interface OneOrMore extends RegexConstruct {
@@ -25,16 +23,22 @@ export interface Optional extends RegexConstruct {
   behavior: QuantifierBehavior;
 }
 
-export function zeroOrMore(sequence: RegexSequence, options?: QuantifierOptions): ZeroOrMore {
+export function zeroOrMore(
+  sequence: RegexSequence,
+  behavior: QuantifierBehavior = 'greedy',
+): ZeroOrMore {
   return {
     type: 'zeroOrMore',
-    options: { behavior: validateBehavior(options?.behavior) },
+    behavior: validateBehavior(behavior),
     children: ensureArray(sequence),
     encode: encodeZeroOrMore,
   };
 }
 
-export function oneOrMore(sequence: RegexSequence, behavior?: QuantifierBehavior): OneOrMore {
+export function oneOrMore(
+  sequence: RegexSequence,
+  behavior: QuantifierBehavior = 'greedy',
+): OneOrMore {
   return {
     type: 'oneOrMore',
     behavior: validateBehavior(behavior),
@@ -43,7 +47,10 @@ export function oneOrMore(sequence: RegexSequence, behavior?: QuantifierBehavior
   };
 }
 
-export function optional(sequence: RegexSequence, behavior?: QuantifierBehavior): Optional {
+export function optional(
+  sequence: RegexSequence,
+  behavior: QuantifierBehavior = 'greedy',
+): Optional {
   return {
     type: 'optional',
     behavior: validateBehavior(behavior),
@@ -55,7 +62,7 @@ export function optional(sequence: RegexSequence, behavior?: QuantifierBehavior)
 function encodeZeroOrMore(this: ZeroOrMore): EncodeResult {
   return {
     precedence: 'sequence',
-    pattern: `${encodeAtom(this.children).pattern}*${this.options.behavior === 'lazy' ? '?' : ''}`,
+    pattern: `${encodeAtom(this.children).pattern}*${this.behavior === 'lazy' ? '?' : ''}`,
   };
 }
 
@@ -73,10 +80,10 @@ function encodeOptional(this: Optional): EncodeResult {
   };
 }
 
-export function validateBehavior(behavior: QuantifierBehavior | undefined): QuantifierBehavior {
-  if (behavior !== undefined && behavior !== 'lazy' && behavior !== 'greedy') {
+export function validateBehavior(behavior: QuantifierBehavior): QuantifierBehavior {
+  if (behavior !== 'lazy' && behavior !== 'greedy') {
     throw new Error(`Invalid quantifier behavior: ${behavior}`);
   }
 
-  return behavior ?? 'greedy';
+  return behavior;
 }

--- a/src/constructs/quantifiers.ts
+++ b/src/constructs/quantifiers.ts
@@ -3,58 +3,50 @@ import type { EncodeResult } from '../encoder/types';
 import { ensureArray } from '../utils/elements';
 import type { RegexConstruct, RegexElement, RegexSequence } from '../types';
 
-export type QuantifierBehavior = 'greedy' | 'lazy';
-
+export interface QuantifierOptions {
+  greedy?: boolean;
+}
 export interface ZeroOrMore extends RegexConstruct {
   type: 'zeroOrMore';
   children: RegexElement[];
-  behavior: QuantifierBehavior;
+  options?: QuantifierOptions;
 }
 
 export interface OneOrMore extends RegexConstruct {
   type: 'oneOrMore';
   children: RegexElement[];
-  behavior: QuantifierBehavior;
+  options?: QuantifierOptions;
 }
 
 export interface Optional extends RegexConstruct {
   type: 'optional';
   children: RegexElement[];
-  behavior: QuantifierBehavior;
+  options?: QuantifierOptions;
 }
 
-export function zeroOrMore(
-  sequence: RegexSequence,
-  behavior: QuantifierBehavior = 'greedy',
-): ZeroOrMore {
+export function zeroOrMore(sequence: RegexSequence, options?: QuantifierOptions): ZeroOrMore {
   return {
     type: 'zeroOrMore',
-    behavior: validateBehavior(behavior),
     children: ensureArray(sequence),
+    options,
     encode: encodeZeroOrMore,
   };
 }
 
-export function oneOrMore(
-  sequence: RegexSequence,
-  behavior: QuantifierBehavior = 'greedy',
-): OneOrMore {
+export function oneOrMore(sequence: RegexSequence, options?: QuantifierOptions): OneOrMore {
   return {
     type: 'oneOrMore',
-    behavior: validateBehavior(behavior),
     children: ensureArray(sequence),
+    options,
     encode: encodeOneOrMore,
   };
 }
 
-export function optional(
-  sequence: RegexSequence,
-  behavior: QuantifierBehavior = 'greedy',
-): Optional {
+export function optional(sequence: RegexSequence, options?: QuantifierOptions): Optional {
   return {
     type: 'optional',
-    behavior: validateBehavior(behavior),
     children: ensureArray(sequence),
+    options,
     encode: encodeOptional,
   };
 }
@@ -62,28 +54,20 @@ export function optional(
 function encodeZeroOrMore(this: ZeroOrMore): EncodeResult {
   return {
     precedence: 'sequence',
-    pattern: `${encodeAtom(this.children).pattern}*${this.behavior === 'lazy' ? '?' : ''}`,
+    pattern: `${encodeAtom(this.children).pattern}*${this.options?.greedy === false ? '?' : ''}`,
   };
 }
 
 function encodeOneOrMore(this: OneOrMore): EncodeResult {
   return {
     precedence: 'sequence',
-    pattern: `${encodeAtom(this.children).pattern}+${this.behavior === 'lazy' ? '?' : ''}`,
+    pattern: `${encodeAtom(this.children).pattern}+${this.options?.greedy === false ? '?' : ''}`,
   };
 }
 
 function encodeOptional(this: Optional): EncodeResult {
   return {
     precedence: 'sequence',
-    pattern: `${encodeAtom(this.children).pattern}?${this.behavior === 'lazy' ? '?' : ''}`,
+    pattern: `${encodeAtom(this.children).pattern}?${this.options?.greedy === false ? '?' : ''}`,
   };
-}
-
-export function validateBehavior(behavior: QuantifierBehavior): QuantifierBehavior {
-  if (behavior !== 'lazy' && behavior !== 'greedy') {
-    throw new Error(`Invalid quantifier behavior: ${behavior}`);
-  }
-
-  return behavior;
 }

--- a/src/constructs/repeat.ts
+++ b/src/constructs/repeat.ts
@@ -16,7 +16,7 @@ export type RepeatCount = number | { min: number; max?: number };
 export function repeat(
   sequence: RegexSequence,
   count: RepeatCount,
-  behavior?: QuantifierBehavior,
+  behavior: QuantifierBehavior = 'greedy',
 ): Repeat {
   const children = ensureArray(sequence);
 


### PR DESCRIPTION
### Summary

This PR implements "lazy" (== "non-greedy") variants of base quantifiers (`??`, `*?`, `+?`) and repeat (`{...}?`).

This PR  currently uses following syntax, simulating Swift enums in JS convention:

```ts
optional([...], "lazy");
zeroOrMore([...], "lazy");
oneOrMore([...], "lazy");
repeat([...], 3, "lazy");
repeat([...], { min: 1, max: 5 }, "lazy");
```

This feature could also use some alternative syntax, here are couple of possible versions:
1. "lazy" as prefix:
```ts
lazyOptional([...]);
lazyZeroOrMore([...]);
lazyOneOrMore([...]);
lazyRepeat([...], 3);
lazyRepeat([...], { min: 1, max: 5 });
```

2. "lazy" as suffix:
```ts
optionalLazy([...]);
zeroOrMoreLazy([...]);
oneOrMoreLazy([...]);
repeatLazy([...], 3);
repeatLazy([...], { min: 1, max: 5 });
```

3. "lazy"  as named option
```ts
optional([...], { behavior: "lazy" });
zeroOrMore([...], { behavior: "lazy" });
oneOrMore([...], { behavior: "lazy" });
repeat([...], { count: 3, behavior: "lazy" });
repeat([...], { min: 1, max: 5, behavior: "lazy" });
```

### Test plan

Added relevant unit tests.
