### PR TITLE
refactor: add missing exports

### DIFF
--- a/src/__tests__/builder.test.ts
+++ b/src/__tests__/builder.test.ts
@@ -1,4 +1,4 @@
-import { buildRegExp } from '../builders';
+import { buildRegExp } from '..';
 
 test('`regexBuilder` flags', () => {
   expect(buildRegExp('a').flags).toBe('');

--- a/src/__tests__/example-email.ts
+++ b/src/__tests__/example-email.ts
@@ -8,7 +8,7 @@ import {
   oneOrMore,
   repeat,
   startOfString,
-} from '../index';
+} from '..';
 
 test('example: email validation', () => {
   const usernameChars = charClass(charRange('a', 'z'), digit, anyOf('._%+-'));

--- a/src/__tests__/example-hashtags.ts
+++ b/src/__tests__/example-hashtags.ts
@@ -1,5 +1,4 @@
-import { buildRegExp } from '../builders';
-import { capture, oneOrMore, word } from '../index';
+import { buildRegExp, capture, oneOrMore, word } from '..';
 
 test('example: extracting hashtags', () => {
   const regex = buildRegExp(

--- a/src/__tests__/example-hex-color.ts
+++ b/src/__tests__/example-hex-color.ts
@@ -8,7 +8,7 @@ import {
   optional,
   repeat,
   startOfString,
-} from '../index';
+} from '..';
 
 test('example: hex color validation', () => {
   const hexDigit = charClass(digit, charRange('a', 'f'));

--- a/src/__tests__/example-ipv4.ts
+++ b/src/__tests__/example-ipv4.ts
@@ -1,12 +1,4 @@
-import {
-  buildRegExp,
-  charRange,
-  choiceOf,
-  digit,
-  endOfString,
-  repeat,
-  startOfString,
-} from '../index';
+import { buildRegExp, charRange, choiceOf, digit, endOfString, repeat, startOfString } from '..';
 
 test('example: IPv4 address validator', () => {
   const octet = choiceOf(

--- a/src/__tests__/example-js-number.ts
+++ b/src/__tests__/example-js-number.ts
@@ -8,7 +8,7 @@ import {
   optional,
   startOfString,
   zeroOrMore,
-} from '../index';
+} from '..';
 
 test('example: validate JavaScript number', () => {
   const sign = anyOf('+-');

--- a/src/__tests__/example-regexp.ts
+++ b/src/__tests__/example-regexp.ts
@@ -1,4 +1,4 @@
-import { buildRegExp, choiceOf, endOfString, repeat, startOfString } from '../index';
+import { buildRegExp, choiceOf, endOfString, repeat, startOfString } from '..';
 
 test('example: mixing with RegExp literals (IPv4 address validator)', () => {
   const octet = choiceOf(

--- a/src/__tests__/example-url.ts
+++ b/src/__tests__/example-url.ts
@@ -10,7 +10,7 @@ import {
   optional,
   startOfString,
   zeroOrMore,
-} from '../index';
+} from '..';
 
 // Modified from: https://stackoverflow.com/a/2015516
 test('example: simple url validation', () => {

--- a/src/constructs/__tests__/anchors.test.tsx
+++ b/src/constructs/__tests__/anchors.test.tsx
@@ -1,5 +1,4 @@
-import { endOfString, startOfString } from '../anchors';
-import { oneOrMore } from '../quantifiers';
+import { endOfString, oneOrMore, startOfString } from '../..';
 
 test('`startOfString` basic cases', () => {
   expect(startOfString).toEqualRegex(/^/);

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -1,5 +1,4 @@
-import { capture } from '../capture';
-import { oneOrMore } from '../quantifiers';
+import { capture, oneOrMore } from '../..';
 
 test('`capture` base cases', () => {
   expect(capture('a')).toEqualRegex(/(a)/);

--- a/src/constructs/__tests__/character-class.test.ts
+++ b/src/constructs/__tests__/character-class.test.ts
@@ -1,7 +1,7 @@
-import { oneOrMore, optional, zeroOrMore } from '../quantifiers';
 import {
   any,
   anyOf,
+  buildRegExp,
   charClass,
   charRange,
   digit,
@@ -9,10 +9,12 @@ import {
   notDigit,
   notWhitespace,
   notWord,
+  oneOrMore,
+  optional,
   whitespace,
   word,
-} from '../character-class';
-import { buildRegExp } from '../../builders';
+  zeroOrMore,
+} from '../..';
 
 test('`any` character class', () => {
   expect(any).toEqualRegex(/./);

--- a/src/constructs/__tests__/choice-of.test.ts
+++ b/src/constructs/__tests__/choice-of.test.ts
@@ -1,6 +1,4 @@
-import { oneOrMore, zeroOrMore } from '../quantifiers';
-import { repeat } from '../repeat';
-import { choiceOf } from '../choice-of';
+import { choiceOf, oneOrMore, repeat, zeroOrMore } from '../..';
 
 test('`choiceOf` using basic strings', () => {
   expect(choiceOf('a')).toEqualRegex(/a/);

--- a/src/constructs/__tests__/quantifiers.test.tsx
+++ b/src/constructs/__tests__/quantifiers.test.tsx
@@ -1,6 +1,4 @@
-import { buildRegExp } from '../../builders';
-import { any, digit } from '../character-class';
-import { oneOrMore, optional, zeroOrMore } from '../quantifiers';
+import { any, buildRegExp, digit, oneOrMore, optional, zeroOrMore } from '../..';
 
 test('`oneOrMore` quantifier', () => {
   expect(oneOrMore('a')).toEqualRegex(/a+/);

--- a/src/constructs/__tests__/repeat.test.tsx
+++ b/src/constructs/__tests__/repeat.test.tsx
@@ -1,6 +1,4 @@
-import { digit } from '../character-class';
-import { oneOrMore, zeroOrMore } from '../quantifiers';
-import { repeat } from '../repeat';
+import { digit, oneOrMore, repeat, zeroOrMore } from '../..';
 
 test('`repeat` quantifier', () => {
   expect(['a', repeat('b', { min: 1, max: 5 })]).toEqualRegex(/ab{1,5}/);

--- a/src/encoder/__tests__/encoder.test.tsx
+++ b/src/encoder/__tests__/encoder.test.tsx
@@ -1,8 +1,4 @@
-import { buildPattern, buildRegExp } from '../../builders';
-import { capture } from '../../constructs/capture';
-import { choiceOf } from '../../constructs/choice-of';
-import { oneOrMore, optional, zeroOrMore } from '../../constructs/quantifiers';
-import { repeat } from '../../constructs/repeat';
+import { buildRegExp, capture, choiceOf, oneOrMore, optional, repeat, zeroOrMore } from '../..';
 
 test('basic quantifies', () => {
   expect('a').toEqualRegex(/a/);
@@ -26,7 +22,7 @@ test('basic quantifies', () => {
   expect([optional('a'), 'b', oneOrMore('d')]).toEqualRegex(/a?bd+/);
 });
 
-test('`buildPattern` escapes special characters', () => {
+test('`buildRegExp` escapes special characters', () => {
   expect('.').toEqualRegex(/\./);
   expect('*').toEqualRegex(/\*/);
   expect('+').toEqualRegex(/\+/);

--- a/src/encoder/__tests__/encoder.test.tsx
+++ b/src/encoder/__tests__/encoder.test.tsx
@@ -1,4 +1,13 @@
-import { buildRegExp, capture, choiceOf, oneOrMore, optional, repeat, zeroOrMore } from '../..';
+import {
+  buildPattern,
+  buildRegExp,
+  capture,
+  choiceOf,
+  oneOrMore,
+  optional,
+  repeat,
+  zeroOrMore,
+} from '../..';
 
 test('basic quantifies', () => {
   expect('a').toEqualRegex(/a/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ export {
   charRange,
   charClass,
   inverted,
+  notDigit,
+  notWhitespace,
+  notWord,
 } from './constructs/character-class';
 export { choiceOf } from './constructs/choice-of';
 export { oneOrMore, optional, zeroOrMore } from './constructs/quantifiers';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add exports for `notDigit`, `notWord` and `notWhitespace` missing in release v1.3.0.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
