### PR TITLE
feat: common patterns infrastructure (hex color)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
   ],
   "exports": {
     ".": {
+      "require": "./lib/commonjs/index",
       "import": "./lib/module/index",
-      "require": "./lib/commonjs/index"
+      "types": "./lib/typescript/src/index.d.ts"
     },
     "./patterns": {
+      "require": "./lib/commonjs/patterns/index",
       "import": "./lib/module/patterns/index",
-      "require": "./lib/commonjs/patterns/index"
+      "types": "./lib/typescript/src/patterns/index.d.ts"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
     "!**/__mocks__",
     "!**/.*"
   ],
+  "exports": {
+    ".": {
+      "import": "./lib/module/index",
+      "require": "./lib/commonjs/index"
+    },
+    "./patterns": {
+      "import": "./lib/module/patterns/index",
+      "require": "./lib/commonjs/patterns/index"
+    }
+  },
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --noEmit",

--- a/src/patterns/__tests__/hex-color.test.ts
+++ b/src/patterns/__tests__/hex-color.test.ts
@@ -1,0 +1,22 @@
+import { hexColorFinder, hexColorValidator } from '..';
+
+test('hexColorValidator', () => {
+  expect(hexColorValidator).toMatchString('#ffffff');
+  expect(hexColorValidator).toMatchString('#000');
+
+  expect(hexColorValidator).not.toMatchString('#000 ');
+  expect(hexColorValidator).not.toMatchString(' #000');
+  expect(hexColorValidator).not.toMatchString('#0');
+  expect(hexColorValidator).not.toMatchString('#11');
+  expect(hexColorValidator).not.toMatchString('#4444');
+  expect(hexColorValidator).not.toMatchString('#55555');
+  expect(hexColorValidator).not.toMatchString('#7777777');
+});
+
+test('hexColorFinder', () => {
+  expect(hexColorFinder).toMatchAllGroups('The color is #ffffff', [['#ffffff']]);
+  expect(hexColorFinder).toMatchAllGroups('The colors are #1, #22, #333, #4444, #55555, #666666', [
+    ['#333'],
+    ['#666666'],
+  ]);
+});

--- a/src/patterns/hex-color.ts
+++ b/src/patterns/hex-color.ts
@@ -1,5 +1,5 @@
 import { buildRegExp } from '../builders';
-import { endOfString, startOfString } from '../constructs/anchors';
+import { endOfString, startOfString, wordBoundary } from '../constructs/anchors';
 import { charClass, charRange, digit } from '../constructs/character-class';
 import { choiceOf } from '../constructs/choice-of';
 import { repeat } from '../constructs/repeat';
@@ -14,8 +14,9 @@ export const hexColorFinder = buildRegExp(
       repeat(hexDigit, 6), // #rrggbb
       repeat(hexDigit, 3), // #rgb
     ),
+    wordBoundary,
   ],
-  { ignoreCase: true },
+  { ignoreCase: true, global: true },
 );
 
 /**

--- a/src/patterns/hex-color.ts
+++ b/src/patterns/hex-color.ts
@@ -2,7 +2,6 @@ import { buildRegExp } from '../builders';
 import { endOfString, startOfString } from '../constructs/anchors';
 import { charClass, charRange, digit } from '../constructs/character-class';
 import { choiceOf } from '../constructs/choice-of';
-import { optional } from '../constructs/quantifiers';
 import { repeat } from '../constructs/repeat';
 
 const hexDigit = charClass(digit, charRange('a', 'f'));
@@ -22,19 +21,17 @@ export const hexColorFinder = buildRegExp(
 /**
  * Check that given text is a valid hex color.
  *
- * Allows both 3 and 6 digit hex colors, with or without the leading `#`.
+ * Allows both 3 and 6 digit hex colors.
  * */
 export const hexColorValidator = buildRegExp(
   [
     startOfString, // Match whole string
-    optional('#'),
+    '#',
     choiceOf(
       repeat(hexDigit, 6), // #rrggbb
       repeat(hexDigit, 3), // #rgb
     ),
     endOfString,
   ],
-  {
-    ignoreCase: true,
-  },
+  { ignoreCase: true },
 );

--- a/src/patterns/hex-color.ts
+++ b/src/patterns/hex-color.ts
@@ -1,0 +1,40 @@
+import { buildRegExp } from '../builders';
+import { endOfString, startOfString } from '../constructs/anchors';
+import { charClass, charRange, digit } from '../constructs/character-class';
+import { choiceOf } from '../constructs/choice-of';
+import { optional } from '../constructs/quantifiers';
+import { repeat } from '../constructs/repeat';
+
+const hexDigit = charClass(digit, charRange('a', 'f'));
+
+/** Find hex color strings in a text. */
+export const hexColorFinder = buildRegExp(
+  [
+    '#',
+    choiceOf(
+      repeat(hexDigit, 6), // #rrggbb
+      repeat(hexDigit, 3), // #rgb
+    ),
+  ],
+  { ignoreCase: true },
+);
+
+/**
+ * Check that given text is a valid hex color.
+ *
+ * Allows both 3 and 6 digit hex colors, with or without the leading `#`.
+ * */
+export const hexColorValidator = buildRegExp(
+  [
+    startOfString, // Match whole string
+    optional('#'),
+    choiceOf(
+      repeat(hexDigit, 6), // #rrggbb
+      repeat(hexDigit, 3), // #rgb
+    ),
+    endOfString,
+  ],
+  {
+    ignoreCase: true,
+  },
+);

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -1,0 +1,1 @@
+export { hexColorFinder, hexColorValidator } from './hex-color';


### PR DESCRIPTION
### Summary

First of the series of common patters: hex color.

This PR defined `finder` and `validator` variants for hex color pattern.

Note this feature will not be yet mentioned in the documentation to confirm that commonjs/esm import works as intended after release.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
