### PR TITLE
feat: named capture groups and reference (alternative approach)

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,4 +1,6 @@
 import './test-utils/to-equal-regex';
 import './test-utils/to-match-groups';
 import './test-utils/to-match-all-groups';
+import './test-utils/to-match-named-groups';
+import './test-utils/to-match-all-named-groups';
 import './test-utils/to-match-string';

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -12,14 +12,15 @@ import {
 
 test('example: html tag matching', () => {
   const tagName = oneOrMore(charClass(charRange('a', 'z'), digit));
+  const tagContent = zeroOrMore(any, { greedy: false });
 
   const tagRef = ref('tag');
   const tagMatcher = buildRegExp(
     [
       '<',
-      capture(tagName, { ref: tagRef }),
+      capture(tagName, { name: tagRef }),
       '>',
-      capture(zeroOrMore(any, { greedy: false }), { name: 'content' }),
+      capture(tagContent, { name: 'content' }),
       '</',
       tagRef,
       '>',

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -17,9 +17,9 @@ test('example: html tag matching', () => {
   const tagMatcher = buildRegExp(
     [
       '<',
-      capture(tagName, { as: tagRef }),
+      capture(tagName, { ref: tagRef }),
       '>',
-      capture(zeroOrMore(any, { greedy: false }), { as: 'content' }),
+      capture(zeroOrMore(any, { greedy: false }), { name: 'content' }),
       '</',
       tagRef,
       '>',

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -6,7 +6,7 @@ import {
   charRange,
   digit,
   oneOrMore,
-  reference,
+  ref,
   zeroOrMore,
 } from '..';
 
@@ -14,7 +14,7 @@ test('example: html tag matching', () => {
   const tagName = oneOrMore(charClass(charRange('a', 'z'), digit));
   const tagContent = zeroOrMore(any, { greedy: false });
 
-  const tagRef = reference('tag');
+  const tagRef = ref('tag');
   const tagMatcher = buildRegExp(
     [
       '<',

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -1,0 +1,42 @@
+import {
+  any,
+  buildRegExp,
+  capture,
+  charClass,
+  charRange,
+  digit,
+  oneOrMore,
+  ref,
+  zeroOrMore,
+} from '..';
+
+test('example: html tag matching', () => {
+  const tagName = oneOrMore(charClass(charRange('a', 'z'), digit));
+
+  const tagRef = ref('tag');
+  const tagMatcher = buildRegExp(
+    [
+      '<',
+      capture(tagName, { as: tagRef }),
+      '>',
+      capture(zeroOrMore(any, { greedy: false }), { as: 'content' }),
+      '</',
+      tagRef,
+      '>',
+    ],
+    { ignoreCase: true, global: true },
+  );
+
+  expect(tagMatcher).toMatchAllNamedGroups('<a>abc</a>', [{ tag: 'a', content: 'abc' }]);
+  expect(tagMatcher).toMatchAllNamedGroups('<a><b>abc</b></a>', [
+    { tag: 'a', content: '<b>abc</b>' },
+  ]);
+  expect(tagMatcher).toMatchAllNamedGroups('<a>abc1</a><b>abc2</b>', [
+    { tag: 'a', content: 'abc1' },
+    { tag: 'b', content: 'abc2' },
+  ]);
+
+  expect(tagMatcher).not.toMatchString('<a>abc</b>');
+
+  expect(tagMatcher).toEqualRegex('<(?<tag>[a-z\\d]+)>(?<content>.*?)<\\/\\k<tag>>');
+});

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -1,8 +1,14 @@
 import { any, buildRegExp, capture, oneOrMore, zeroOrMore } from '..';
 
 test('example: html tag matching', () => {
-  const tagName = capture(oneOrMore(/[a-z0-9]/), { name: 'tag' });
-  const tagContent = capture(zeroOrMore(any, { greedy: false }), { name: 'content' });
+  const tagName = capture(
+    oneOrMore(/[a-z0-9]/), //
+    { name: 'tag' },
+  );
+  const tagContent = capture(
+    zeroOrMore(any, { greedy: false }), //
+    { name: 'content' },
+  );
 
   const tagMatcher = buildRegExp(['<', tagName, '>', tagContent, '</', tagName.ref(), '>'], {
     ignoreCase: true,
@@ -20,5 +26,5 @@ test('example: html tag matching', () => {
 
   expect(tagMatcher).not.toMatchString('<a>abc</b>');
 
-  expect(tagMatcher).toEqualRegex('<(?<tag>[a-z\\d]+)>(?<content>.*?)<\\/\\k<tag>>');
+  expect(tagMatcher).toEqualRegex('<(?<tag>[a-z0-9]+)>(?<content>.*?)<\\/\\k<tag>>');
 });

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -6,7 +6,7 @@ import {
   charRange,
   digit,
   oneOrMore,
-  ref,
+  reference,
   zeroOrMore,
 } from '..';
 
@@ -14,7 +14,7 @@ test('example: html tag matching', () => {
   const tagName = oneOrMore(charClass(charRange('a', 'z'), digit));
   const tagContent = zeroOrMore(any, { greedy: false });
 
-  const tagRef = ref('tag');
+  const tagRef = reference('tag');
   const tagMatcher = buildRegExp(
     [
       '<',

--- a/src/__tests__/example-html-tags.ts
+++ b/src/__tests__/example-html-tags.ts
@@ -1,32 +1,13 @@
-import {
-  any,
-  buildRegExp,
-  capture,
-  charClass,
-  charRange,
-  digit,
-  oneOrMore,
-  ref,
-  zeroOrMore,
-} from '..';
+import { any, buildRegExp, capture, oneOrMore, zeroOrMore } from '..';
 
 test('example: html tag matching', () => {
-  const tagName = oneOrMore(charClass(charRange('a', 'z'), digit));
-  const tagContent = zeroOrMore(any, { greedy: false });
+  const tagName = capture(oneOrMore(/[a-z0-9]/), { name: 'tag' });
+  const tagContent = capture(zeroOrMore(any, { greedy: false }), { name: 'content' });
 
-  const tagRef = ref('tag');
-  const tagMatcher = buildRegExp(
-    [
-      '<',
-      capture(tagName, { name: tagRef }),
-      '>',
-      capture(tagContent, { name: 'content' }),
-      '</',
-      tagRef,
-      '>',
-    ],
-    { ignoreCase: true, global: true },
-  );
+  const tagMatcher = buildRegExp(['<', tagName, '>', tagContent, '</', tagName.ref(), '>'], {
+    ignoreCase: true,
+    global: true,
+  });
 
   expect(tagMatcher).toMatchAllNamedGroups('<a>abc</a>', [{ tag: 'a', content: 'abc' }]);
   expect(tagMatcher).toMatchAllNamedGroups('<a><b>abc</b></a>', [

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -6,7 +6,7 @@ import {
   digit,
   inverted,
   oneOrMore,
-  ref,
+  reference,
   word,
   wordBoundary,
 } from '../..';
@@ -50,21 +50,21 @@ test('named `capture` matching', () => {
 });
 
 // Should have `ref0` as name.
-const firstRef = ref();
+const firstRef = reference();
 
 test('`reference` pattern', () => {
   expect([firstRef]).toEqualRegex(/\k<ref0>/);
-  expect([ref('xyz')]).toEqualRegex(/\k<xyz>/);
+  expect([reference('xyz')]).toEqualRegex(/\k<xyz>/);
   expect([capture(any, { name: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
 
-  const otherRef = ref('r123');
+  const otherRef = reference('r123');
   expect(['xx', capture(any, { name: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
     'xx(?<r123>.) \\k<r123>xx',
   );
 });
 
 test('`reference` matching basic case', () => {
-  const someRef = ref();
+  const someRef = reference();
   expect([capture(word, { name: someRef }), someRef]).toMatchString('aa');
   expect([capture(digit, { name: someRef }), someRef]).toMatchString('11');
 
@@ -75,7 +75,7 @@ test('`reference` matching basic case', () => {
 });
 
 test('`reference` matching HTML attributes', () => {
-  const quoteRef = ref('quote');
+  const quoteRef = reference('quote');
   const quote = anyOf('"\'');
   const htmlAttributeRegex = buildRegExp([
     wordBoundary,

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -25,27 +25,28 @@ test('`capture` matching', () => {
 });
 
 test('named `capture` pattern', () => {
-  expect(capture('a', { as: 'xyz' })).toEqualRegex('(?<xyz>a)');
-  expect(capture('abc', { as: 'xyz' })).toEqualRegex('(?<xyz>abc)');
-  expect(capture(oneOrMore('abc'), { as: 'xyz' })).toEqualRegex('(?<xyz>(?:abc)+)');
-  expect(oneOrMore(capture('abc', { as: 'xyz' }))).toEqualRegex('(?<xyz>abc)+');
+  expect(capture('a', { name: 'xyz' })).toEqualRegex('(?<xyz>a)');
+  expect(capture('abc', { name: 'xyz' })).toEqualRegex('(?<xyz>abc)');
+  expect(capture(oneOrMore('abc'), { name: 'xyz' })).toEqualRegex('(?<xyz>(?:abc)+)');
+  expect(oneOrMore(capture('abc', { name: 'xyz' }))).toEqualRegex('(?<xyz>abc)+');
 });
 
 test('named `capture` matching', () => {
-  expect(capture('b', { as: 'x1' })).toMatchGroups('ab', ['b', 'b']);
-  expect(capture('b', { as: 'x1' })).toMatchNamedGroups('ab', { x1: 'b' });
+  expect(capture('b', { name: 'x1' })).toMatchGroups('ab', ['b', 'b']);
+  expect(capture('b', { name: 'x1' })).toMatchNamedGroups('ab', { x1: 'b' });
 
-  expect(['a', capture('b', { as: 'x1' })]).toMatchGroups('ab', ['ab', 'b']);
-  expect(['a', capture('b', { as: 'x1' })]).toMatchNamedGroups('ab', { x1: 'b' });
+  expect(['a', capture('b', { name: 'x1' })]).toMatchGroups('ab', ['ab', 'b']);
+  expect(['a', capture('b', { name: 'x1' })]).toMatchNamedGroups('ab', { x1: 'b' });
 
-  expect([capture('a'), capture('b', { as: 'x1' }), capture('c', { as: 'x2' })]).toMatchGroups(
+  expect([capture('a'), capture('b', { name: 'x1' }), capture('c', { name: 'x2' })]).toMatchGroups(
     'abc',
     ['abc', 'a', 'b', 'c'],
   );
-  expect([capture('a'), capture('b', { as: 'x1' }), capture('c', { as: 'x2' })]).toMatchNamedGroups(
-    'abc',
-    { x1: 'b', x2: 'c' },
-  );
+  expect([
+    capture('a'),
+    capture('b', { name: 'x1' }),
+    capture('c', { name: 'x2' }),
+  ]).toMatchNamedGroups('abc', { x1: 'b', x2: 'c' });
 });
 
 // Should have `ref0` as name.
@@ -54,23 +55,23 @@ const firstRef = ref();
 test('`reference` pattern', () => {
   expect([firstRef]).toEqualRegex(/\k<ref0>/);
   expect([ref('xyz')]).toEqualRegex(/\k<xyz>/);
-  expect([capture(any, { as: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
+  expect([capture(any, { ref: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
 
   const otherRef = ref('r123');
-  expect(['xx', capture(any, { as: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
+  expect(['xx', capture(any, { ref: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
     'xx(?<r123>.) \\k<r123>xx',
   );
 });
 
 test('`reference` matching basic case', () => {
   const someRef = ref();
-  expect([capture(word, { as: someRef }), someRef]).toMatchString('aa');
-  expect([capture(digit, { as: someRef }), someRef]).toMatchString('11');
+  expect([capture(word, { ref: someRef }), someRef]).toMatchString('aa');
+  expect([capture(digit, { ref: someRef }), someRef]).toMatchString('11');
 
-  expect([capture(any, { as: someRef }), someRef]).not.toMatchString('ab');
+  expect([capture(any, { ref: someRef }), someRef]).not.toMatchString('ab');
 
-  expect([capture(digit, { as: someRef }), someRef]).not.toMatchString('1a');
-  expect([capture(digit, { as: someRef }), someRef]).not.toMatchString('a1');
+  expect([capture(digit, { ref: someRef }), someRef]).not.toMatchString('1a');
+  expect([capture(digit, { ref: someRef }), someRef]).not.toMatchString('a1');
 });
 
 test('`reference` matching HTML attributes', () => {
@@ -78,10 +79,10 @@ test('`reference` matching HTML attributes', () => {
   const quote = anyOf('"\'');
   const htmlAttributeRegex = buildRegExp([
     wordBoundary,
-    capture(oneOrMore(word), { as: 'name' }),
+    capture(oneOrMore(word), { name: 'name' }),
     '=',
-    capture(quote, { as: quoteRef }),
-    capture(oneOrMore(inverted(quote)), { as: 'value' }),
+    capture(quote, { ref: quoteRef }),
+    capture(oneOrMore(inverted(quote)), { name: 'value' }),
     quoteRef,
   ]);
 

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -4,9 +4,8 @@ import {
   buildRegExp,
   capture,
   digit,
-  inverted,
+  negated,
   oneOrMore,
-  ref,
   word,
   wordBoundary,
 } from '../..';
@@ -49,41 +48,41 @@ test('named `capture` matching', () => {
   ]).toMatchNamedGroups('abc', { x1: 'b', x2: 'c' });
 });
 
-// Should have `ref0` as name.
-const firstRef = ref();
+test('`ref` function', () => {
+  const someCapture = capture(any, { name: 'ref0' });
+  expect([someCapture, ' ', someCapture.ref()]).toEqualRegex('(?<ref0>.) \\k<ref0>');
 
-test('`reference` pattern', () => {
-  expect([firstRef]).toEqualRegex(/\k<ref0>/);
-  expect([ref('xyz')]).toEqualRegex(/\k<xyz>/);
-  expect([capture(any, { name: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
-
-  const otherRef = ref('r123');
-  expect(['xx', capture(any, { name: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
+  const otherCapture = capture(any, { name: 'r123' });
+  expect(['xx', otherCapture, ' ', otherCapture.ref(), 'xx']).toEqualRegex(
     'xx(?<r123>.) \\k<r123>xx',
   );
 });
 
 test('`reference` matching basic case', () => {
-  const someRef = ref();
-  expect([capture(word, { name: someRef }), someRef]).toMatchString('aa');
-  expect([capture(digit, { name: someRef }), someRef]).toMatchString('11');
+  const wordCapture = capture(word, { name: 'word' });
+  expect([wordCapture, wordCapture.ref()]).toMatchString('aa');
 
-  expect([capture(any, { name: someRef }), someRef]).not.toMatchString('ab');
+  const digitCapture = capture(digit, { name: 'digit' });
+  expect([digitCapture, digitCapture.ref()]).toMatchString('11');
 
-  expect([capture(digit, { name: someRef }), someRef]).not.toMatchString('1a');
-  expect([capture(digit, { name: someRef }), someRef]).not.toMatchString('a1');
+  const anyCapture = capture(any, { name: 'any' });
+  expect([anyCapture, anyCapture.ref()]).not.toMatchString('ab');
+
+  expect([digitCapture, digitCapture.ref()]).not.toMatchString('1a');
+  expect([digitCapture, digitCapture.ref()]).not.toMatchString('a1');
 });
 
 test('`reference` matching HTML attributes', () => {
-  const quoteRef = ref('quote');
   const quote = anyOf('"\'');
+  const quoteCapture = capture(quote, { name: 'quote' });
+
   const htmlAttributeRegex = buildRegExp([
     wordBoundary,
     capture(oneOrMore(word), { name: 'name' }),
     '=',
-    capture(quote, { name: quoteRef }),
-    capture(oneOrMore(inverted(quote)), { name: 'value' }),
-    quoteRef,
+    quoteCapture,
+    capture(oneOrMore(negated(quote)), { name: 'value' }),
+    quoteCapture.ref(),
   ]);
 
   expect(htmlAttributeRegex).toMatchNamedGroups('a="b"', {

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -1,4 +1,15 @@
-import { capture, oneOrMore } from '../..';
+import {
+  any,
+  anyOf,
+  buildRegExp,
+  capture,
+  digit,
+  inverted,
+  oneOrMore,
+  ref,
+  word,
+  wordBoundary,
+} from '../..';
 
 test('`capture` pattern', () => {
   expect(capture('a')).toEqualRegex(/(a)/);
@@ -11,4 +22,97 @@ test('`capture` matching', () => {
   expect(capture('b')).toMatchGroups('ab', ['b', 'b']);
   expect(['a', capture('b')]).toMatchGroups('ab', ['ab', 'b']);
   expect(['a', capture('b'), capture('c')]).toMatchGroups('abc', ['abc', 'b', 'c']);
+});
+
+test('named `capture` pattern', () => {
+  expect(capture('a', { as: 'xyz' })).toEqualRegex('(?<xyz>a)');
+  expect(capture('abc', { as: 'xyz' })).toEqualRegex('(?<xyz>abc)');
+  expect(capture(oneOrMore('abc'), { as: 'xyz' })).toEqualRegex('(?<xyz>(?:abc)+)');
+  expect(oneOrMore(capture('abc', { as: 'xyz' }))).toEqualRegex('(?<xyz>abc)+');
+});
+
+test('named `capture` matching', () => {
+  expect(capture('b', { as: 'x1' })).toMatchGroups('ab', ['b', 'b']);
+  expect(capture('b', { as: 'x1' })).toMatchNamedGroups('ab', { x1: 'b' });
+
+  expect(['a', capture('b', { as: 'x1' })]).toMatchGroups('ab', ['ab', 'b']);
+  expect(['a', capture('b', { as: 'x1' })]).toMatchNamedGroups('ab', { x1: 'b' });
+
+  expect([capture('a'), capture('b', { as: 'x1' }), capture('c', { as: 'x2' })]).toMatchGroups(
+    'abc',
+    ['abc', 'a', 'b', 'c'],
+  );
+  expect([capture('a'), capture('b', { as: 'x1' }), capture('c', { as: 'x2' })]).toMatchNamedGroups(
+    'abc',
+    { x1: 'b', x2: 'c' },
+  );
+});
+
+// Should have `ref0` as name.
+const firstRef = ref();
+
+test('`reference` pattern', () => {
+  expect([firstRef]).toEqualRegex(/\k<ref0>/);
+  expect([ref('xyz')]).toEqualRegex(/\k<xyz>/);
+  expect([capture(any, { as: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
+
+  const otherRef = ref('r123');
+  expect(['xx', capture(any, { as: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
+    'xx(?<r123>.) \\k<r123>xx',
+  );
+});
+
+test('`reference` matching basic case', () => {
+  const someRef = ref();
+  expect([capture(word, { as: someRef }), someRef]).toMatchString('aa');
+  expect([capture(digit, { as: someRef }), someRef]).toMatchString('11');
+
+  expect([capture(any, { as: someRef }), someRef]).not.toMatchString('ab');
+
+  expect([capture(digit, { as: someRef }), someRef]).not.toMatchString('1a');
+  expect([capture(digit, { as: someRef }), someRef]).not.toMatchString('a1');
+});
+
+test('`reference` matching HTML attributes', () => {
+  const quoteRef = ref('quote');
+  const quote = anyOf('"\'');
+  const htmlAttributeRegex = buildRegExp([
+    wordBoundary,
+    capture(oneOrMore(word), { as: 'name' }),
+    '=',
+    capture(quote, { as: quoteRef }),
+    capture(oneOrMore(inverted(quote)), { as: 'value' }),
+    quoteRef,
+  ]);
+
+  expect(htmlAttributeRegex).toMatchNamedGroups('a="b"', {
+    name: 'a',
+    quote: '"',
+    value: 'b',
+  });
+  expect(htmlAttributeRegex).toMatchNamedGroups('aa="bbb"', {
+    name: 'aa',
+    quote: '"',
+    value: 'bbb',
+  });
+  expect(htmlAttributeRegex).toMatchNamedGroups(`aa='bbb'`, {
+    name: 'aa',
+    quote: `'`,
+    value: 'bbb',
+  });
+  expect(htmlAttributeRegex).toMatchNamedGroups('<input type="number" />', {
+    quote: '"',
+    name: 'type',
+    value: 'number',
+  });
+  expect(htmlAttributeRegex).toMatchNamedGroups(`<input type='number' />`, {
+    quote: "'",
+    name: 'type',
+    value: 'number',
+  });
+
+  expect(htmlAttributeRegex).not.toMatchString(`aa="bbb'`);
+  expect(htmlAttributeRegex).not.toMatchString(`aa='bbb"`);
+  expect(htmlAttributeRegex).not.toMatchString(`<input type='number" />`);
+  expect(htmlAttributeRegex).not.toMatchString(`<input type="number' />`);
 });

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -55,23 +55,23 @@ const firstRef = ref();
 test('`reference` pattern', () => {
   expect([firstRef]).toEqualRegex(/\k<ref0>/);
   expect([ref('xyz')]).toEqualRegex(/\k<xyz>/);
-  expect([capture(any, { ref: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
+  expect([capture(any, { name: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
 
   const otherRef = ref('r123');
-  expect(['xx', capture(any, { ref: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
+  expect(['xx', capture(any, { name: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
     'xx(?<r123>.) \\k<r123>xx',
   );
 });
 
 test('`reference` matching basic case', () => {
   const someRef = ref();
-  expect([capture(word, { ref: someRef }), someRef]).toMatchString('aa');
-  expect([capture(digit, { ref: someRef }), someRef]).toMatchString('11');
+  expect([capture(word, { name: someRef }), someRef]).toMatchString('aa');
+  expect([capture(digit, { name: someRef }), someRef]).toMatchString('11');
 
-  expect([capture(any, { ref: someRef }), someRef]).not.toMatchString('ab');
+  expect([capture(any, { name: someRef }), someRef]).not.toMatchString('ab');
 
-  expect([capture(digit, { ref: someRef }), someRef]).not.toMatchString('1a');
-  expect([capture(digit, { ref: someRef }), someRef]).not.toMatchString('a1');
+  expect([capture(digit, { name: someRef }), someRef]).not.toMatchString('1a');
+  expect([capture(digit, { name: someRef }), someRef]).not.toMatchString('a1');
 });
 
 test('`reference` matching HTML attributes', () => {
@@ -81,7 +81,7 @@ test('`reference` matching HTML attributes', () => {
     wordBoundary,
     capture(oneOrMore(word), { name: 'name' }),
     '=',
-    capture(quote, { ref: quoteRef }),
+    capture(quote, { name: quoteRef }),
     capture(oneOrMore(inverted(quote)), { name: 'value' }),
     quoteRef,
   ]);

--- a/src/constructs/__tests__/capture.test.tsx
+++ b/src/constructs/__tests__/capture.test.tsx
@@ -6,7 +6,7 @@ import {
   digit,
   inverted,
   oneOrMore,
-  reference,
+  ref,
   word,
   wordBoundary,
 } from '../..';
@@ -50,21 +50,21 @@ test('named `capture` matching', () => {
 });
 
 // Should have `ref0` as name.
-const firstRef = reference();
+const firstRef = ref();
 
 test('`reference` pattern', () => {
   expect([firstRef]).toEqualRegex(/\k<ref0>/);
-  expect([reference('xyz')]).toEqualRegex(/\k<xyz>/);
+  expect([ref('xyz')]).toEqualRegex(/\k<xyz>/);
   expect([capture(any, { name: firstRef }), ' ', firstRef]).toEqualRegex('(?<ref0>.) \\k<ref0>');
 
-  const otherRef = reference('r123');
+  const otherRef = ref('r123');
   expect(['xx', capture(any, { name: otherRef }), ' ', otherRef, 'xx']).toEqualRegex(
     'xx(?<r123>.) \\k<r123>xx',
   );
 });
 
 test('`reference` matching basic case', () => {
-  const someRef = reference();
+  const someRef = ref();
   expect([capture(word, { name: someRef }), someRef]).toMatchString('aa');
   expect([capture(digit, { name: someRef }), someRef]).toMatchString('11');
 
@@ -75,7 +75,7 @@ test('`reference` matching basic case', () => {
 });
 
 test('`reference` matching HTML attributes', () => {
-  const quoteRef = reference('quote');
+  const quoteRef = ref('quote');
   const quote = anyOf('"\'');
   const htmlAttributeRegex = buildRegExp([
     wordBoundary,

--- a/src/constructs/capture.ts
+++ b/src/constructs/capture.ts
@@ -11,7 +11,7 @@ export interface Capture extends RegexConstruct {
 
 export type CaptureOptions = {
   /**
-   * Name to be given to the capturing group can either by a string or {@link reference} instance.
+   * Name to be given to the capturing group can either by a string or {@link ref} instance.
    */
   name: string | Reference;
 };
@@ -24,7 +24,7 @@ export interface Reference extends RegexConstruct {
 /**
  * Creates a capturing group which allows the matched pattern to be available:
  * - in the match results (`String.match`, `String.matchAll`, or `RegExp.exec`)
- * - in the regex itself, through {@link reference}
+ * - in the regex itself, through {@link ref}
  */
 export function capture(sequence: RegexSequence, options?: CaptureOptions): Capture {
   return {
@@ -44,7 +44,7 @@ let counter = 0;
  *
  * @param name - Name to be given to the capturing group which receives this reference. If not provided, a unique name will be generated.
  */
-export function reference(name?: string): Reference {
+export function ref(name?: string): Reference {
   return {
     type: 'reference',
     name: name ?? `ref${counter++}`,

--- a/src/constructs/capture.ts
+++ b/src/constructs/capture.ts
@@ -6,19 +6,71 @@ import type { RegexConstruct, RegexElement, RegexSequence } from '../types';
 export interface Capture extends RegexConstruct {
   type: 'capture';
   children: RegexElement[];
+  options?: CaptureOptions;
 }
 
-export function capture(sequence: RegexSequence): Capture {
+export interface CaptureOptions {
+  /**
+   * Either a name to be given to the capturing group or a `Reference` object ({@link ref})
+   * that will allow to match the captured text again later. */
+  as?: Backreference | string;
+}
+
+export interface Backreference extends RegexConstruct {
+  type: 'reference';
+  name: string;
+}
+
+/**
+ * Creates a capturing group which allows the matched pattern to be available:
+ * - in the match results (`String.match`, `String.matchAll`, or `RegExp.exec`)
+ * - in the regex itself, through backreferences (@see ref)
+ */
+export function capture(sequence: RegexSequence, options?: CaptureOptions): Capture {
   return {
     type: 'capture',
     children: ensureArray(sequence),
+    options,
     encode: encodeCapture,
   };
 }
 
+let counter = 0;
+
+/**
+ * Creates a backreference to a capturing group.
+ *
+ * Backreferences allows to match the same text that was previously captured by a capturing group.
+ *
+ * @param name - Name to be given to the capturing group which receives this `Backreference`. If not provided, a unique name will be generated.
+ */
+export function ref(name?: string): Backreference {
+  return {
+    type: 'reference',
+    name: name ?? `ref${counter++}`,
+    encode: encodeReference,
+  };
+}
+
 function encodeCapture(this: Capture): EncodeResult {
+  const ref = this.options?.as;
+  if (ref) {
+    const refName = typeof ref === 'string' ? ref : ref?.name;
+    return {
+      precedence: 'atom',
+      pattern: `(?<${refName}>${encodeSequence(this.children).pattern})`,
+    };
+  }
+
   return {
     precedence: 'atom',
     pattern: `(${encodeSequence(this.children).pattern})`,
+  };
+}
+
+function encodeReference(this: Backreference): EncodeResult {
+  return {
+    precedence: 'atom',
+    pattern: `\\k<${this.name}>`,
   };
 }

--- a/src/constructs/capture.ts
+++ b/src/constructs/capture.ts
@@ -11,7 +11,7 @@ export interface Capture extends RegexConstruct {
 
 export type CaptureOptions = {
   /**
-   * Name to be given to the capturing group can either by a string or {@link ref} instance.
+   * Name to be given to the capturing group can either by a string or {@link reference} instance.
    */
   name: string | Reference;
 };
@@ -24,7 +24,7 @@ export interface Reference extends RegexConstruct {
 /**
  * Creates a capturing group which allows the matched pattern to be available:
  * - in the match results (`String.match`, `String.matchAll`, or `RegExp.exec`)
- * - in the regex itself, through backreferences (@see ref)
+ * - in the regex itself, through {@link reference}
  */
 export function capture(sequence: RegexSequence, options?: CaptureOptions): Capture {
   return {
@@ -44,7 +44,7 @@ let counter = 0;
  *
  * @param name - Name to be given to the capturing group which receives this reference. If not provided, a unique name will be generated.
  */
-export function ref(name?: string): Reference {
+export function reference(name?: string): Reference {
   return {
     type: 'reference',
     name: name ?? `ref${counter++}`,

--- a/src/constructs/capture.ts
+++ b/src/constructs/capture.ts
@@ -7,13 +7,14 @@ export interface Capture extends RegexConstruct {
   type: 'capture';
   children: RegexElement[];
   options?: CaptureOptions;
+  ref: () => Reference;
 }
 
 export type CaptureOptions = {
   /**
    * Name to be given to the capturing group can either by a string or {@link ref} instance.
    */
-  name: string | Reference;
+  name: string;
 };
 
 export interface Reference extends RegexConstruct {
@@ -32,10 +33,15 @@ export function capture(sequence: RegexSequence, options?: CaptureOptions): Capt
     children: ensureArray(sequence),
     options,
     encode: encodeCapture,
+    ref: generateRef,
   };
 }
 
 let counter = 0;
+
+function generateRef(this: Capture) {
+  return ref(this.options?.name ?? 'unknown');
+}
 
 /**
  * Creates a reference (a.k.a. backreference) to a capturing group.

--- a/src/constructs/capture.ts
+++ b/src/constructs/capture.ts
@@ -9,15 +9,13 @@ export interface Capture extends RegexConstruct {
   options?: CaptureOptions;
 }
 
-export type CaptureOptions =
-  | {
-      /** Name to be given to the capturing group. */
-      name: string;
-    }
-  | {
-      /** Reference object ({@link ref}) that will allow to match the captured text again later. */
-      ref: Reference;
-    };
+export type CaptureOptions = {
+  /**
+   * Name to be given to the capturing group can either by a string or {@link ref} instance.
+   */
+  name: string | Reference;
+};
+
 export interface Reference extends RegexConstruct {
   type: 'reference';
   name: string;
@@ -40,11 +38,11 @@ export function capture(sequence: RegexSequence, options?: CaptureOptions): Capt
 let counter = 0;
 
 /**
- * Creates a backreference to a capturing group.
+ * Creates a reference (a.k.a. backreference) to a capturing group.
  *
  * Backreferences allows to match the same text that was previously captured by a capturing group.
  *
- * @param name - Name to be given to the capturing group which receives this `Backreference`. If not provided, a unique name will be generated.
+ * @param name - Name to be given to the capturing group which receives this reference. If not provided, a unique name will be generated.
  */
 export function ref(name?: string): Reference {
   return {
@@ -56,7 +54,7 @@ export function ref(name?: string): Reference {
 
 function encodeCapture(this: Capture): EncodeResult {
   // @ts-expect-error
-  const name = this.options?.ref?.name ?? this.options?.name;
+  const name = this.options?.name?.name ?? this.options?.name;
   if (name) {
     return {
       precedence: 'atom',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
+// Types
 export type * from './types';
+export type { CaptureOptions } from './constructs/capture';
+export type { QuantifierOptions } from './constructs/quantifiers';
+export type { RepeatOptions } from './constructs/repeat';
 
+// Builders
 export { buildPattern, buildRegExp } from './builders';
 
+// Constructs
 export {
   endOfString,
   nonWordBoundary,
@@ -9,7 +15,7 @@ export {
   startOfString,
   wordBoundary,
 } from './constructs/anchors';
-export { capture } from './constructs/capture';
+export { capture, ref } from './constructs/capture';
 export {
   any,
   anyOf,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export {
   startOfString,
   wordBoundary,
 } from './constructs/anchors';
-export { capture, ref } from './constructs/capture';
+export { capture } from './constructs/capture';
 export {
   any,
   anyOf,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export {
   startOfString,
   wordBoundary,
 } from './constructs/anchors';
-export { capture, reference } from './constructs/capture';
+export { capture, ref } from './constructs/capture';
 export {
   any,
   anyOf,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,8 @@ export type { RepeatOptions } from './constructs/repeat';
 export { buildPattern, buildRegExp } from './builders';
 
 // Constructs
-export {
-  endOfString,
-  nonWordBoundary,
-  notWordBoundary,
-  startOfString,
-  wordBoundary,
-} from './constructs/anchors';
-export { capture, ref } from './constructs/capture';
+export { endOfString, notWordBoundary, startOfString, wordBoundary } from './constructs/anchors';
+export { capture, reference } from './constructs/capture';
 export {
   any,
   anyOf,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,13 @@ export type { RepeatOptions } from './constructs/repeat';
 export { buildPattern, buildRegExp } from './builders';
 
 // Constructs
-export { endOfString, notWordBoundary, startOfString, wordBoundary } from './constructs/anchors';
+export {
+  endOfString,
+  nonWordBoundary,
+  notWordBoundary,
+  startOfString,
+  wordBoundary,
+} from './constructs/anchors';
 export { capture, reference } from './constructs/capture';
 export {
   any,

--- a/test-utils/to-equal-regex.ts
+++ b/test-utils/to-equal-regex.ts
@@ -4,7 +4,7 @@ import { wrapRegExp } from './utils';
 export function toEqualRegex(
   this: jest.MatcherContext,
   received: RegExp | RegexSequence,
-  expected: RegExp,
+  expected: RegExp | string,
 ) {
   received = wrapRegExp(received);
 
@@ -12,10 +12,15 @@ export function toEqualRegex(
     isNot: this.isNot,
   };
 
+  const expectedSource = typeof expected === 'string' ? expected : expected.source;
+  const expectedFlags = typeof expected === 'string' ? undefined : expected.flags;
+
   return {
-    pass: expected.source === received.source && expected.flags === received.flags,
+    pass:
+      expectedSource === received.source &&
+      (expectedFlags === undefined || expectedFlags === received.flags),
     message: () =>
-      this.utils.matcherHint('toHavePattern', undefined, undefined, options) +
+      this.utils.matcherHint('toEqualRegex', undefined, undefined, options) +
       '\n\n' +
       `Expected: ${this.isNot ? 'not ' : ''}${this.utils.printExpected(expected)}\n` +
       `Received: ${this.utils.printReceived(received)}`,
@@ -28,7 +33,7 @@ declare global {
   namespace jest {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R, T = {}> {
-      toEqualRegex(expected: RegExp): R;
+      toEqualRegex(expected: RegExp | string): R;
     }
   }
 }

--- a/test-utils/to-match-all-named-groups.ts
+++ b/test-utils/to-match-all-named-groups.ts
@@ -1,15 +1,15 @@
 import type { RegexSequence } from '../src/types';
 import { wrapRegExp } from './utils';
 
-export function toMatchGroups(
+export function toMatchAllNamedGroups(
   this: jest.MatcherContext,
   received: RegExp | RegexSequence,
   inputText: string,
-  expectedGroups: string[],
+  expectedGroups: Array<Record<string, string>>,
 ) {
   const receivedRegex = wrapRegExp(received);
-  const matchResult = inputText.match(receivedRegex);
-  const receivedGroups = matchResult ? [...matchResult] : null;
+  const matchResult = inputText.matchAll(receivedRegex);
+  const receivedGroups = matchResult ? [...matchResult].map((r) => r.groups) : null;
   const options = {
     isNot: this.isNot,
   };
@@ -24,13 +24,13 @@ export function toMatchGroups(
   };
 }
 
-expect.extend({ toMatchGroups });
+expect.extend({ toMatchAllNamedGroups });
 
 declare global {
   namespace jest {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R, T = {}> {
-      toMatchGroups(inputText: string, expectedGroups: string[]): R;
+      toMatchAllNamedGroups(inputText: string, expectedGroups: Array<Record<string, string>>): R;
     }
   }
 }

--- a/test-utils/to-match-named-groups.ts
+++ b/test-utils/to-match-named-groups.ts
@@ -1,15 +1,15 @@
 import type { RegexSequence } from '../src/types';
 import { wrapRegExp } from './utils';
 
-export function toMatchGroups(
+export function toMatchNamedGroups(
   this: jest.MatcherContext,
   received: RegExp | RegexSequence,
   inputText: string,
-  expectedGroups: string[],
+  expectedGroups: Record<string, string>,
 ) {
   const receivedRegex = wrapRegExp(received);
   const matchResult = inputText.match(receivedRegex);
-  const receivedGroups = matchResult ? [...matchResult] : null;
+  const receivedGroups = matchResult ? matchResult.groups : null;
   const options = {
     isNot: this.isNot,
   };
@@ -24,13 +24,13 @@ export function toMatchGroups(
   };
 }
 
-expect.extend({ toMatchGroups });
+expect.extend({ toMatchNamedGroups });
 
 declare global {
   namespace jest {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R, T = {}> {
-      toMatchGroups(inputText: string, expectedGroups: string[]): R;
+      toMatchNamedGroups(inputText: string, expectedGroups: Record<string, string>): R;
     }
   }
 }

--- a/website/docs/api/captures.md
+++ b/website/docs/api/captures.md
@@ -35,33 +35,29 @@ TS Regex Builder does not have a construct for non-capturing groups. Such groups
 
 :::
 
-### `ref()`
+### `Capture.ref()`
 
 ```ts
-function ref(
-  name?: string;
-): Reference;
+function Capture.ref(): Backreference;
 ```
 
 Regex syntax: `\k<...>`.
 
-Creates a reference, also known as backreferences, which allows matching the same text again that was previously matched by a capturing group. To form a valid regex, reference need to be attached to named capturing group earlier in the expression.
-
-If you do not specify the reference name, a auto-generated unique value will be assigned for it.
+Creates a backreference, allowing the exact text, previously matched by a capturing group, to be matched again. This construct is not a standalone function but a method available on a `Capture` construct instance, which should be assigned to a variable.
 
 Usage with `capture()`:
 
 ```ts
-// Define reference with name "some".
-const someRef = ref('some');
+// Define a capture as a variable.
+const someCapture = capture([...], { name: 'some' });
 
 const regex = buildRegExp([
   // Create a named capture using name from `someRef`.
-  capture(..., { name: someRef }),
+  someCapture,
   // ... some other elements ...
   // Match the same text as captured in a `capture` using `someRef`.
-  someRef,
-  ])
+  someCapture.ref(),
+])
 ```
 
 :::note

--- a/website/docs/api/captures.md
+++ b/website/docs/api/captures.md
@@ -35,10 +35,10 @@ TS Regex Builder does not have a construct for non-capturing groups. Such groups
 
 :::
 
-### `reference()`
+### `ref()`
 
 ```ts
-function reference(
+function ref(
   name?: string;
 ): Reference;
 ```
@@ -53,13 +53,13 @@ Usage with `capture()`:
 
 ```ts
 // Define reference with name "some".
-const someRef = reference('some');
+const someRef = ref('some');
 
 const regex = buildRegExp([
   // Create a named capture using name from `someRef`.
-  capture(..., { name: someRef}),
+  capture(..., { name: someRef }),
   // ... some other elements ...
-  // Match the same text as captured in capture using `someRef`.
+  // Match the same text as captured in a `capture` using `someRef`.
   someRef,
   ])
 ```

--- a/website/docs/api/captures.md
+++ b/website/docs/api/captures.md
@@ -10,14 +10,15 @@ function capture(
   sequence: RegexSequence,
   options?: {
     name?: string;
+    ref?: string;
   },
 ): Capture;
 ```
 
 Regex syntax:
 
-- `(...)` for capturing groups
-- `(?<name>...)` for named capturing groups
+- `(...)` for capturing groups (no `name` option)
+- `(?<name>...)` for named capturing groups (`name` or `ref` option)
 
 Captures, also known as capturing groups, extract and store parts of the matched string for later use.
 

--- a/website/docs/api/captures.md
+++ b/website/docs/api/captures.md
@@ -10,7 +10,6 @@ function capture(
   sequence: RegexSequence,
   options?: {
     name?: string;
-    ref?: string;
   },
 ): Capture;
 ```
@@ -18,7 +17,7 @@ function capture(
 Regex syntax:
 
 - `(...)` for capturing groups (no `name` option)
-- `(?<name>...)` for named capturing groups (`name` or `ref` option)
+- `(?<name>...)` for named capturing groups (`name` option)
 
 Captures, also known as capturing groups, extract and store parts of the matched string for later use.
 
@@ -46,7 +45,22 @@ function ref(
 
 Regex syntax: `\k<...>`.
 
-References, also known as backreferences, allow matching the same text again that was previously matched by a capturing group.
+Creates a reference, also known as backreferences, which allows matching the same text again that was previously matched by a capturing group. To form a valid regex, reference need to be attached to named capturing group earlier in the expression.
+
+If you do not specify the reference name, a auto-generated unique value will be assigned for it.
+
+Usage with `capture()`:
+
+```ts
+// Define ref with name "some".
+const someRef = ref('some');
+
+const regex = buildRegExp([
+  capture(..., { ref: someRef}), // Here you make a named capture using name from `someRef`.
+  // ...
+  someRef, // Here you match the same text as captured in capture using `someRef`.
+  ])
+```
 
 :::note
 

--- a/website/docs/api/captures.md
+++ b/website/docs/api/captures.md
@@ -35,10 +35,10 @@ TS Regex Builder does not have a construct for non-capturing groups. Such groups
 
 :::
 
-### `ref()`
+### `reference()`
 
 ```ts
-function ref(
+function reference(
   name?: string;
 ): Reference;
 ```
@@ -52,13 +52,15 @@ If you do not specify the reference name, a auto-generated unique value will be 
 Usage with `capture()`:
 
 ```ts
-// Define ref with name "some".
-const someRef = ref('some');
+// Define reference with name "some".
+const someRef = reference('some');
 
 const regex = buildRegExp([
-  capture(..., { ref: someRef}), // Here you make a named capture using name from `someRef`.
-  // ...
-  someRef, // Here you match the same text as captured in capture using `someRef`.
+  // Create a named capture using name from `someRef`.
+  capture(..., { name: someRef}),
+  // ... some other elements ...
+  // Match the same text as captured in capture using `someRef`.
+  someRef,
   ])
 ```
 

--- a/website/docs/api/captures.md
+++ b/website/docs/api/captures.md
@@ -1,0 +1,54 @@
+---
+id: captures
+title: Captures
+---
+
+### `capture()`
+
+```ts
+function capture(
+  sequence: RegexSequence,
+  options?: {
+    name?: string;
+  },
+): Capture;
+```
+
+Regex syntax:
+
+- `(...)` for capturing groups
+- `(?<name>...)` for named capturing groups
+
+Captures, also known as capturing groups, extract and store parts of the matched string for later use.
+
+Capture results are available using array-like [`match()` result object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#using_match).
+
+#### Named groups
+
+When using `name` options, the group becomes a [named capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) allowing to refer to it using name instead of index.
+
+Named capture results are available using [`groups`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#using_named_capturing_groups) property on `match()` result.
+
+:::note
+
+TS Regex Builder does not have a construct for non-capturing groups. Such groups are implicitly added when required. E.g., `zeroOrMore("abc")` is encoded as `(?:abc)+`.
+
+:::
+
+### `ref()`
+
+```ts
+function ref(
+  name?: string;
+): Reference;
+```
+
+Regex syntax: `\k<...>`.
+
+References, also known as backreferences, allow matching the same text again that was previously matched by a capturing group.
+
+:::note
+
+TS Regex Builder doesn't support using ordinal backreferences (`\1`, `\2`, etc) because in complex regex patterns, these references are difficult to accurately use.
+
+:::

--- a/website/docs/api/constructs.md
+++ b/website/docs/api/constructs.md
@@ -19,24 +19,6 @@ The `choiceOf` (disjunction) construct matches one out of several possible seque
 
 Example: `choiceOf("color", "colour")` matches either `color` or `colour` pattern.
 
-### `capture()`
-
-```ts
-function capture(
-  sequence: RegexSequence,
-): Capture;
-```
-
-Regex syntax: `(...)`.
-
-Captures, also known as capturing groups, extract and store parts of the matched string for later use.
-
-:::note
-
-TS Regex Builder does not have a construct for non-capturing groups. Such groups are implicitly added when required. E.g., `zeroOrMore("abc")` is encoded as `(?:abc)+`.
-
-:::
-
 ### `regex()`
 
 ```ts

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -29,6 +29,7 @@ export default {
         'api/types',
         'api/builder',
         'api/constructs',
+        'api/captures',
         'api/quantifiers',
         'api/character-classes',
         'api/assertions',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This is an alternative syntax for backreferences proposed by @Killavus. 

```ts
// Define a capture as a variable.
const someCapture = capture([...], { name: 'some' });

const regex = buildRegExp([
  // Create a named capture using name from `someRef`.
  someCapture,
  // ... some other elements ...
  // Match the same text as captured in a `capture` using `someRef`.
  someCapture.ref(),
])
```

It requires assigning a capture group to a JS variable which then can generate a backreference by calling `.ref()` method on it.

### Comparison to #66 
Pros:
- more natural flow: from capture to reference
- more compact in the main expression, as `capture` needs to be assigned to a separate variable

Cons:
- requires assigning capture to a separate variable, not possible to have `capture` in the main regex expression
- requires assigning explicit `name` for capture, as we want to avoid creating named capturing group with automatically generated name if not needed.
- deviates from Swift Regex Builder pattern: https://developer.apple.com/documentation/regexbuilder/reference

Real life example (HTML open-closing tags matching):
```ts
test('example: html tag matching', () => {
  const tagName = capture(
    oneOrMore(/[a-z0-9]/),
    { name: 'tag' },
  );
  const tagContent = capture(
    zeroOrMore(any, { greedy: false }),
    { name: 'content' },
  );

  const tagMatcher = buildRegExp(['<', tagName, '>', tagContent, '</', tagName.ref(), '>'], {
    ignoreCase: true,
    global: true,
  });

  expect(tagMatcher).toMatchAllNamedGroups('<a>abc</a>', [{ tag: 'a', content: 'abc' }]);
});
```

@PaulJPhilp pls take a look at this approach vs the one in #66 .


### Test plan

Added automated tests & real-life example.