### PR TITLE
fix: prevent embedding `any` (`.`) in `charClass`

### DIFF
--- a/src/constructs/__tests__/character-class.test.ts
+++ b/src/constructs/__tests__/character-class.test.ts
@@ -90,7 +90,6 @@ test('`charClass` throws on negated arguments', () => {
 });
 
 test('`charClass` joins character escapes', () => {
-  expect(charClass(any)).toEqualRegex(/./);
   expect(charClass(word)).toEqualRegex(/\w/);
   expect(charClass(digit)).toEqualRegex(/\d/);
   expect(charClass(whitespace)).toEqualRegex(/\s/);
@@ -98,14 +97,11 @@ test('`charClass` joins character escapes', () => {
   expect(charClass(nonDigit)).toEqualRegex(/\D/);
   expect(charClass(nonWhitespace)).toEqualRegex(/\S/);
 
-  expect(charClass(any, whitespace)).toEqualRegex(/[.\s]/);
-  expect(charClass(any, nonWhitespace)).toEqualRegex(/[.\S]/);
+  expect(charClass(whitespace, nonWhitespace)).toEqualRegex(/[\s\S]/);
 
   expect(charClass(word, whitespace)).toEqualRegex(/[\w\s]/);
-  expect(charClass(any, word, digit)).toEqualRegex(/[.\w\d]/);
-
   expect(charClass(word, digit, whitespace)).toEqualRegex(/[\w\d\s]/);
-  expect(charClass(any, word, digit, whitespace)).toEqualRegex(/[.\w\d\s]/);
+  expect(charClass(word, nonDigit)).toEqualRegex(/[\w\D]/);
 });
 
 test('`charRange` pattern', () => {

--- a/src/constructs/character-class.ts
+++ b/src/constructs/character-class.ts
@@ -18,13 +18,13 @@ export interface CharacterRange {
   end: string;
 }
 
-export const any: CharacterClass = {
-  type: 'characterClass',
-  escape: '.',
-  chars: [],
-  ranges: [],
-  isNegated: false,
-  encode: encodeCharacterClass,
+/**
+ * Matches any single character.
+ * Cannot be used as a part of character class.
+ */
+export const any: EncodeResult = {
+  precedence: 'atom',
+  pattern: '.',
 };
 
 export const digit: CharacterClass = {

--- a/src/encoder/encoder.ts
+++ b/src/encoder/encoder.ts
@@ -20,7 +20,11 @@ function encodeNode(element: RegexElement): EncodeResult {
     return encodeRegExp(element);
   }
 
-  if (typeof element.encode !== 'function') {
+  if (typeof element === 'object' && 'pattern' in element) {
+    return element;
+  }
+
+  if (typeof element === 'object' && typeof element.encode !== 'function') {
     throw new Error(`\`encodeNode\`: unknown element type ${element.type}`);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type RegexSequence = RegexElement[] | RegexElement;
 /**
  * Fundamental building block of a regular expression, defined as either a regex construct or a string.
  */
-export type RegexElement = RegexConstruct | string | RegExp;
+export type RegexElement = RegexConstruct | EncodeResult | string | RegExp;
 
 /**
  * Common interface for all regex constructs like character classes, quantifiers, and anchors.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

`any` (regex: `.`) could be added to char class

```
any // => /./ - ok matches any char
charClass(any) // => /[.]/ - not ok, `.` in char class looses special meaning and matchers literal dot
```

### Test plan

Adapt automated tests
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
